### PR TITLE
Updated installation steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,55 @@
 # supervised-grns
 Supervised inference of gene regulatory networks from single-cell RNA-sequencing data
+
+## Installation
+
+### Download the code on your machine
+```git clone https://github.com/Murali-group/supervised-grns.git```
+
+### Setting up conda environment and dependencies
+We recommend using an [Anaconda](https://www.anaconda.com/) environment to run the pipeline. The below steps can be followed on your Ubuntu machine to get the pipeline setup and running.
+#### Install conda and activate the environment
+* Install Anaconda from the official website [here](https://www.anaconda.com/products/individual#Downloads)
+* After you have Anaconda installed on your machine, we will create a conda environment specific for this project. This project works on ```Python3```
+  ```bash
+  conda create -n "SGRN" python=3.7.10 ipython
+  ```
+  * This will create an environment called ```SGRN``` with ```Python 3.7.10```
+  * Activate the environment with the command 
+    ```bash
+    conda activate SGRN
+    ```
+  * We will now install the required packages and dependencies in the ```SGRN``` environment.
+#### Install dependencies
+* supervised-grns pipeline mainly uses ```PyTorch``` framework for its computation, amongst other libraries. We found that installing ```PyTorch``` can be tricky so we split this step into two - 
+  * Install ```PyTorch``` and related modules
+  * Install rest of the packages through ``` pip install requirements.txt``
+
+
+* In this step, we will install ```PyTorch``` library along with the necessary dependencies.
+  * Install PyTorch in your environment with the following command - ```conda install -c pytorch pytorch```
+  * Check if PyTorch is installed and check the version. You should get an output like this -
+    ``` bash 
+    python -c "import torch; print(torch.__version__)"
+    1.8.0
+    ```
+  * Similarly, install ```torchvision``` and check if is correctly installed -
+    ``` bash
+    conda install -c pytorch torchvision
+    python -c "import torchvision; print(torchvision.__version__)"
+    0.9.0
+    ```
+  * Finally, the ```PyTorch geometric``` library can be installed by following the steps [here](https://pytorch-geometric.readthedocs.io/en/latest/notes/installation.html) listed under __Installation via Binaries__
+* We now install the rest of the libraries using the ```requirements.txt``` file.
+  ```bash 
+  pip install requirements.txt
+  ```
+That's it! We can now run the pipeline and check if everything is working fine.
+
+## Run the pipeline
+
+Navigate to your folder where the code is downloaded. Run the following command to test the running of the pipeline.
+```bash
+ python main.py --config=config/config.yaml 
+ ```
+

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ We recommend using an [Anaconda](https://www.anaconda.com/) environment to run t
 #### Install dependencies
 * supervised-grns pipeline mainly uses ```PyTorch``` framework for its computation, amongst other libraries. We found that installing ```PyTorch``` can be tricky so we split this step into two - 
   * Install ```PyTorch``` and related modules
-  * Install rest of the packages through ``` pip install requirements.txt``
+  * Install rest of the packages through ``` pip install requirements.txt```
 
 
 * In this step, we will install ```PyTorch``` library along with the necessary dependencies.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,2 @@
-torch==1.5.0
-networkx==2.4
-pandas==1.0.1
-numpy==1.18.1
-tqdm==4.42.1
-torchvision==0.6.0
-matplotlib==3.1.3
-torch_geometric==1.4.3
-scikit_learn==0.24.1
+pyyaml==5.4.1
+tensorboard==2.4.1


### PR DESCRIPTION
Updated the documentation with detailed instructions to install supervised-grns on Ubuntu.
Since installing the pipeline directly through requirements.txt was causing an issue - majorly because of conflicts between PyTorch and its dependencies - I have split the installation into two parts.
First, install PyTorch and its related libraries. This will automatically install libraries such as scikit-learn, numpy etc and hence we do not need to explicitly install them again.
Second, we install the rest of the packages such as  yaml, tensorboard which did not get installed when PyTorch was installed.